### PR TITLE
This fixes the URL change at NOAA from HTTP to HTTPS

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: utils
 Priority: optional
 Maintainer: Kees Leune <kees@leune.org>
 Standards-Version: 3.9.6
-Build-Depends: libcurl3-gnutls-dev, debhelper (>=9)
+Build-Depends: libcurl4-openssl-dev, debhelper (>=9)
 Homepage: http://github.com/keesl/metar
 
 Package: metar

--- a/src/metar.h
+++ b/src/metar.h
@@ -24,7 +24,7 @@
 #define  METAR_MAXSIZE 512
 
 /* where to fetch reports */
-#define  METARURL "http://tgftp.nws.noaa.gov/data/observations/metar/stations"
+#define  METARURL "https://tgftp.nws.noaa.gov/data/observations/metar/stations"
 
 /* clouds */
 typedef struct {


### PR DESCRIPTION
The metar tool stopped working on February 4th 2019 due to an URL change from HTTP on HTTPS at NOAA.
The HTTP URL now returns a redirect to the HTTPS version, however the metar tool doesn't follow redirects so no data is returned anymore.
This tiny fix switches to the HTTPS URL.
