### PR TITLE
Support increased verbosity for debugging curl

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -86,6 +86,7 @@ int download_Metar(char *station) {
     curl_easy_setopt(curlhandle, CURLOPT_URL, url);
     curl_easy_setopt(curlhandle, CURLOPT_FOLLOWLOCATION, 1);
 	curl_easy_setopt(curlhandle, CURLOPT_WRITEFUNCTION, receiveData);
+	if (verbose > 1) curl_easy_setopt(curlhandle, CURLOPT_VERBOSE, 1L);
 	memset(noaabuffer, 0x0, METAR_MAXSIZE);
 
 	res = curl_easy_perform(curlhandle);
@@ -172,7 +173,7 @@ int main(int argc, char* argv[]) {
 				decode=1;
 				break;
 			case 'v':
-				verbose=1;
+				verbose++;
 				break;
 		}
 	}


### PR DESCRIPTION
This resolves my issues with #8, please let me know if it needs to be rebased.

```console
$ src/metar -vv -d kiad
Retrieving URL https://tgftp.nws.noaa.gov/data/observations/metar/stations/KIAD.TXT
*   Trying 140.90.101.79...
* TCP_NODELAY set
* Connected to tgftp.nws.noaa.gov (140.90.101.79) port 443 (#0)
* ALPN, offering http/1.1
* Cipher selection: ALL:!EXPORT:!EXPORT40:!EXPORT56:!aNULL:!LOW:!RC4:@STRENGTH
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/certs/ca-certificates.crt
  CApath: /etc/ssl/certs
* SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384
* ALPN, server accepted to use http/1.1
* Server certificate:
*  subject: OU=Domain Control Validated; CN=dev.ncep.noaa.gov
*  start date: Feb  8 14:24:24 2019 GMT
*  expire date: Jan 27 15:34:06 2020 GMT
*  subjectAltName: host "tgftp.nws.noaa.gov" matched cert's "tgftp.nws.noaa.gov"
*  issuer: C=US; ST=Arizona; L=Scottsdale; O=GoDaddy.com, Inc.; OU=http://certs.godaddy.com/repository/; CN=Go Daddy Secure Certificate Authority - G2
*  SSL certificate verify ok.
> GET /data/observations/metar/stations/KIAD.TXT HTTP/1.1
Host: tgftp.nws.noaa.gov
Accept: */*

< HTTP/1.1 200 OK
< Date: Wed, 13 Feb 2019 05:22:27 GMT
< Server: Apache
< X-Frame-Options: SAMEORIGIN
< X-Content-Type-Options: nosniff
< X-XSS-Protection: 1; mode=block
< Last-Modified: Wed, 13 Feb 2019 04:54:17 GMT
< Accept-Ranges: bytes
< Content-Length: 156
< Vary: Accept-Encoding
< Content-Type: text/plain; charset=UTF-8
< Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
< 
* Curl_http_done: called premature == 0
* Connection #0 to host tgftp.nws.noaa.gov left intact
KIAD 130452Z 26004KT 1SM R01R/P6000FT BR OVC004 02/01 A2966 RMK AO2 SFC VIS 4 RAE0354B08E23UPB0354E0355 SLP046 P0000 T00170011 400330000 $
Parsing token `KIAD'
   Found station KIAD
Parsing token `130452Z'
   Found Day/Time 13/452
Parsing token `26004KT'
   Found Winddir/str/gust/unit 260/4/4/KT
Parsing token `1SM'
   Visibility range/unit 1/SM
Parsing token `R01R/P6000FT'
   Unmatched token = R01R/P6000FT
Parsing token `BR'
   Phenomena Mist
Parsing token `OVC004'
   Cloud cover/alt OVC/400
Parsing token `02/01'
   Temp/dewpoint 2/1
Parsing token `A2966'
   Pressure/unit 2966/"Hg
Parsing token `RMK'
   Unmatched token = RMK
Parsing token `AO2'
   Unmatched token = AO2
Parsing token `SFC'
   Unmatched token = SFC
Parsing token `VIS'
   Unmatched token = VIS
Parsing token `4'
   Unmatched token = 4
Parsing token `RAE0354B08E23UPB0354E0355'
   Unmatched token = RAE0354B08E23UPB0354E0355
Parsing token `SLP046'
   Unmatched token = SLP046
Parsing token `P0000'
   Unmatched token = P0000
Parsing token `T00170011'
   Unmatched token = T00170011
Parsing token `400330000'
   Unmatched token = 400330000
Parsing token `$'
   Unmatched token = $
Station       : KIAD
Day           : 13
Time          : 04:52 UTC
Wind direction: 260 (W)
Wind speed    : 4 KT
Wind gust     : 4 KT
Visibility    : 1 SM
Temperature   : 2 C
Dewpoint      : 1 C
Pressure      : 29.66 "Hg
Clouds        : OVC at 400 ft
Phenomena     : Mist
```